### PR TITLE
feat: remove dist folder before running the extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,14 @@
 			"group": {
 				"kind": "build",
 				"isDefault": true
-			}
+			},
+			"dependsOn": ["Delete_Dist_Folder"]
+		},
+		{
+			"label": "Delete_Dist_Folder",
+			"command": "rm -rf dist",
+			"type": "shell",
+			"group": "build"
 		}
 	]
 }


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🔄 Refactor
- [ ] 💡 Feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏎 Optimization
- [ ] 📄 Documentation Update

## Description
When we run the extension without erasing the `dist` folder first, we might have issues in our debug and false breakpoints.
That way we ensure that the debug mode will run as supposed, without any issues.