### PR TITLE
fix: display sessions on deployment deactivation/activation

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -112,6 +112,11 @@ export class ProjectController {
 			type: MessageType.setSessionsSection,
 			payload: sessionsViewObject,
 		});
+
+		this.view.update({
+			type: MessageType.selectDeployment,
+			payload: deploymentId,
+		});
 	}
 
 	async displaySessionsHistory(sessionId: string): Promise<void> {


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
- [ ]  ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ]  ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ]  ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Description
The bug:
The sessions of the deployment disappear when we are activating/deactivating it.
The source cause it is that when we stop it, the sessions reset but it doesn't change in the controller, so the next time we compare it to the controller state - it doesn't change and we are not pulling the sessions.

The fix:
Reset the value of the sessions to `undefined` to make it pull the relevant sessions in the next pull.
