### PR TITLE
fix: don't pull submodule on github workflow

### DIFF
--- a/.github/workflows/build_test_and_release_app.yml
+++ b/.github/workflows/build_test_and_release_app.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           node-version: "21.2.0"
           cache: "npm"
-      - name: Pull submodule from remote
-        run: git submodule update --remote
       - name: Install dependencies for both vscode and react app
         run: npm ci
       - name: Run vscode and react app tests


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ]  ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ]  ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ]  ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Description
Every time we commit new commits in the branch or merge PRs, the workflow pulls the latest version of autokitteh which in some cases might have breaking changes, like we had here: https://github.com/autokitteh/autokitteh/pull/409.
The solution is not pull new data on every workflow, but use the specific version that we have in the relevant commit.

## Ticket
https://linear.app/autokitteh/issue/UI-73/fix-github-actions-workflow