### PR TITLE
fix: starlark needed executable recognition on windows

### DIFF
--- a/src/services/starlark/starlarkVersionManager.service.ts
+++ b/src/services/starlark/starlarkVersionManager.service.ts
@@ -15,7 +15,7 @@ export class StarlarkVersionManagerService {
 		currentVersion: string,
 		extensionPath: string
 	): Promise<{ path?: string; version?: string; error?: Error; didUpdate: boolean }> {
-		const platform = os.platform();
+		const platform = StarlarkVersionManagerService.determinePlatform();
 		const arch = StarlarkVersionManagerService.determineArchitecture();
 
 		const { data: latestRelease, error: releaseError } = await StarlarkVersionManagerService.fetchLatestReleaseInfo(
@@ -154,5 +154,15 @@ export class StarlarkVersionManagerService {
 	private static determineArchitecture(): string {
 		const archMappings: Record<string, string> = { x64: "x86_64", arm64: "x86_64" };
 		return archMappings[os.arch()] || os.arch();
+	}
+
+	private static determinePlatform(): string {
+		let platform = os.platform().toString();
+
+		// TODO: Sync in the future with the supported platforms in our LSP versions.
+		if (platform === "win32") {
+			platform = "windows";
+		}
+		return platform;
 	}
 }


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ]  ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ]  ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ]  ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Description
Temporary patch, the platform as defined in NodeJS has only one option for windows: "win32".
On the other hand, in our [backend executable](https://github.com/autokitteh/autokitteh/releases/tag/v0.3.1) the architecture is defined as "windows".
Therefore, we need this adjustment.

![image](https://github.com/autokitteh/vscode-extension/assets/7413072/545186a4-0086-48c1-b6ab-6509c563ce26)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-190/vscode-adjust-the-starlarklsp-executable-to-a-relevant-platform-by