### PR TITLE
feat: control notifications level in extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,21 @@
 					"description": "Refresh interval in seconds for the sidebar panel",
 					"type": "number"
 				},
+				"autokitteh.notificationsLevel": {
+					"type": "string",
+					"default": "All",
+					"enum": [
+						"All",
+						"Errors",
+						"None"
+					],
+					"description": "Adjust notification visibility in the extension, ranging from all notifications to errors only, or none",
+					"enumDescriptions": [
+						"Displays all notifications (info, errors)",
+						"Only shows error notifications",
+						"Suppresses all notifications"
+					]
+				},
 				"autokitteh.starlarkLSPPath": {
 					"default": "",
 					"description": "The path to the starlark LSP Server",

--- a/src/utilities/vsCodeMessageHandler.utils.ts
+++ b/src/utilities/vsCodeMessageHandler.utils.ts
@@ -1,11 +1,20 @@
 import { LoggerService } from "@services";
+import { WorkspaceConfig } from "@utilities/workspaceConfig.util";
 import { window } from "vscode";
 
 export class MessageHandler {
+	private static notificationsLevel = WorkspaceConfig.getFromWorkspace<string>("notificationsLevel", "");
+
 	static infoMessage(messageText: string): void {
+		if (this.notificationsLevel !== "All") {
+			return;
+		}
 		window.showInformationMessage(messageText);
 	}
 	static errorMessage(messageText: string): void {
+		if (this.notificationsLevel === "None") {
+			return;
+		}
 		window.showErrorMessage(messageText, "View log").then((selection) => {
 			if (selection === "View log") {
 				LoggerService.reveal();


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->

## What type of PR is this? (check all applicable)

- [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ]  ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ]  ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ]  ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Description
* Allow the user to control the level of notification that he wants to see: All notifications, errors only, or none.