### PR TITLE
fix: display session history when switching to running session

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -215,6 +215,7 @@ export class ProjectController {
 		if (isEqual(this.sessionHistoryStates, sessionHistoryStates)) {
 			return;
 		}
+		this.sessionHistoryStates = sessionHistoryStates;
 
 		LoggerService.clearOutputChannel(channels.appOutputSessionsLogName);
 		this.outputSessionLogs(sessionHistoryStates);
@@ -228,8 +229,6 @@ export class ProjectController {
 			this.stopInterval(ProjectIntervalTypes.sessionHistory);
 			return;
 		}
-
-		this.sessionHistoryStates = sessionHistoryStates;
 	}
 
 	private outputSessionLogs(sessionStates: SessionLogRecord[]) {
@@ -266,9 +265,6 @@ export class ProjectController {
 	async displaySessionLogs(sessionId: string): Promise<void> {
 		this.stopInterval(ProjectIntervalTypes.sessionHistory);
 		this.selectedSessionId = sessionId;
-
-		this.sessions = [];
-		this.displaySessionsHistory(sessionId);
 
 		this.startInterval(
 			ProjectIntervalTypes.sessionHistory,

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -267,6 +267,9 @@ export class ProjectController {
 		this.stopInterval(ProjectIntervalTypes.sessionHistory);
 		this.selectedSessionId = sessionId;
 
+		this.sessions = [];
+		this.displaySessionsHistory(sessionId);
+
 		this.startInterval(
 			ProjectIntervalTypes.sessionHistory,
 			() => this.displaySessionsHistory(sessionId),


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ]  ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ]  ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ]  ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Description
**The issue:**
When we had a running session, we changed the selection to another (completed) session and swapped back to the running session, the log was not changed back to the running, until the next update of the running session.

**The fix:**
Reset the sessionHistoryStates state on the session selection change.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-206/vscode-display-session-history-when-switching-to-running-session