### PR TITLE
fix: display appropriate message on reconnecting status

### DIFF
--- a/src/controllers/sidebar.controller.ts
+++ b/src/controllers/sidebar.controller.ts
@@ -1,3 +1,4 @@
+import { Code, ConnectError } from "@connectrpc/connect";
 import { namespaces, vsCommands } from "@constants";
 import { getResources } from "@controllers/utilities";
 import { translate } from "@i18n";
@@ -40,7 +41,11 @@ export class SidebarController {
 				namespaces.projectSidebarController,
 				translate().t("projects.fetchProjectsFailedError", { error: (error as Error).message })
 			);
-			return [{ label: translate().t("projects.cantFetchProjectsReconnecting"), key: undefined }];
+			if ((error as ConnectError).code === Code.Unavailable || (error as ConnectError).code === Code.Aborted) {
+				return [{ label: translate().t("general.reconnecting"), key: undefined }];
+			} else {
+				return [{ label: translate().t("general.internalError"), key: undefined }];
+			}
 		}
 		if (projects!.length) {
 			return projects!.map((project) => ({

--- a/src/controllers/sidebar.controller.ts
+++ b/src/controllers/sidebar.controller.ts
@@ -40,7 +40,7 @@ export class SidebarController {
 				namespaces.projectSidebarController,
 				translate().t("projects.fetchProjectsFailedError", { error: (error as Error).message })
 			);
-			return;
+			return [{ label: translate().t("projects.cantFetchProjectsReconnecting"), key: undefined }];
 		}
 		if (projects!.length) {
 			return projects!.map((project) => ({

--- a/src/i18n/en/general.i18n.json
+++ b/src/i18n/en/general.i18n.json
@@ -1,3 +1,5 @@
 {
-	"companyName": "autokitteh"
+	"companyName": "autokitteh",
+	"reconnecting": "Reconnecting...",
+	"internalError": "Internal error"
 }

--- a/src/i18n/en/projects.i18n.json
+++ b/src/i18n/en/projects.i18n.json
@@ -2,6 +2,7 @@
 	"clickHere": "Click here to enable the extension",
 	"projects": "Projects",
 	"noProjectsFound": "No projects found",
+	"cantFetchProjectsReconnecting": "Reconnecting...",
 	"openProject": "Open project",
 	"projectBuildSucceed": "Project build succeed - id: {{id}}",
 	"projectBuildFailed": "Project build failed - id: {{id}}",

--- a/src/i18n/en/projects.i18n.json
+++ b/src/i18n/en/projects.i18n.json
@@ -2,7 +2,6 @@
 	"clickHere": "Click here to enable the extension",
 	"projects": "Projects",
 	"noProjectsFound": "No projects found",
-	"cantFetchProjectsReconnecting": "Reconnecting...",
 	"openProject": "Open project",
 	"projectBuildSucceed": "Project build succeed - id: {{id}}",
 	"projectBuildFailed": "Project build failed - id: {{id}}",

--- a/src/views/sidebar.view.ts
+++ b/src/views/sidebar.view.ts
@@ -22,9 +22,15 @@ export class SidebarView implements TreeDataProvider<TreeItem> {
 		this.rootNode = new TreeItem(translate().t("projects.projects"), TreeItemCollapsibleState.Expanded);
 		this.childNodeMap = new Map();
 
+		if (children.length === 1 && children[0].key === undefined) {
+			this.rootNode = new TreeItem(children[0].label, TreeItemCollapsibleState.None);
+			this.childNodeMap.set(this.rootNode, []);
+			return;
+		}
+
 		const childItems = children.map((child: SidebarTreeItem) => {
 			const treeItem = new TreeItem(child.label);
-			treeItem.contextValue = child.key; // Set the key as contextValue
+			treeItem.contextValue = child.key;
 			return treeItem;
 		});
 


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ]  ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ]  ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ]  ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Description
Display proper message when the connectivity with the server fails.

## Screenshots
Before:
![image](https://github.com/autokitteh/vscode-extension/assets/7413072/c1387976-fc25-4660-8a87-d2c7682a4085)

After:
![image](https://github.com/autokitteh/vscode-extension/assets/7413072/2d336181-4e1c-4ded-a23f-c6a893cdc07b)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-205/vscode-display-an-appropriate-message-on-extension-disconnection
