### PR TITLE
fix: fix starlark download when the folder is already exist

### DIFF
--- a/src/services/starlark/starlarkVersionManager.service.ts
+++ b/src/services/starlark/starlarkVersionManager.service.ts
@@ -1,13 +1,13 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { namespaces, starlarkExecutableGithubRepository, starlarkLSPExtractedDirectory } from "@constants";
+import { namespaces, starlarkExecutableGithubRepository, starlarkLSPExtractedDirectory, vsCommands } from "@constants";
 import { translate } from "@i18n";
 import { AssetInfo, GitHubRelease } from "@interfaces";
 import { LoggerService } from "@services";
 import { extractArchive, listFilesInDirectory } from "@utilities";
 import axios from "axios";
-import { window } from "vscode";
+import { commands, window } from "vscode";
 
 export class StarlarkVersionManagerService {
 	public static async updateLSPVersionIfNeeded(
@@ -126,6 +126,12 @@ export class StarlarkVersionManagerService {
 			await extractArchive(filePath, extensionPath);
 		} catch (error) {
 			LoggerService.error(namespaces.startlarkLSPServer, (error as Error).message);
+			
+			commands.executeCommand(
+				vsCommands.showErrorMessage,
+				(error as Error).message
+			);
+
 			return { error: error as Error };
 		}
 

--- a/src/services/starlark/starlarkVersionManager.service.ts
+++ b/src/services/starlark/starlarkVersionManager.service.ts
@@ -122,7 +122,12 @@ export class StarlarkVersionManagerService {
 		await StarlarkVersionManagerService.downloadFile(release.url, filePath);
 		LoggerService.info(namespaces.startlarkLSPServer, translate().t("starlark.executableDownloadedUnpacking"));
 
-		await extractArchive(filePath, extensionPath);
+		try {
+			await extractArchive(filePath, extensionPath);
+		} catch (error) {
+			LoggerService.error(namespaces.startlarkLSPServer, (error as Error).message);
+			return { error: error as Error };
+		}
 
 		const extractedFiles = await listFilesInDirectory(path.join(extensionPath, starlarkLSPExtractedDirectory));
 		if (extractedFiles.length !== 1) {

--- a/src/utilities/archive.utils.ts
+++ b/src/utilities/archive.utils.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { pipeline } from "stream/promises";
 import * as zlib from "zlib";
 import { starlarkLSPExtractedDirectory } from "@constants/starlark.constants";
-import { createDirectory } from "@utilities";
+import { createDirectory, directoryExists } from "@utilities";
 import AdmZip from "adm-zip";
 import tarFs from "tar-fs";
 
@@ -44,7 +44,9 @@ export const extractArchive = async (inputPath: string, outputPath: string): Pro
 	const extractPath = `${outputPath}/${starlarkLSPExtractedDirectory}`;
 
 	try {
-		await createDirectory(extractPath);
+		if (!directoryExists(extractPath)) {
+			await createDirectory(extractPath);
+		}
 
 		switch (type) {
 			case "tar.gz":

--- a/src/utilities/fileSystem.utils.ts
+++ b/src/utilities/fileSystem.utils.ts
@@ -33,6 +33,15 @@ export const createDirectory = async (outputPath: string): Promise<void> => {
 	}
 };
 
+export const directoryExists = async (directoryPath: string): Promise<boolean> => {
+	try {
+		const stat = await fs.promises.stat(directoryPath);
+		return stat.isDirectory();
+	} catch (error) {
+		return false;
+	}
+};
+
 export const listFilesInDirectory = async (dirPath: string, includeDirectories: boolean = false): Promise<string[]> => {
 	const entries = await fsPromises.readdir(dirPath, { withFileTypes: true });
 	const files: string[] = [];

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -16,4 +16,5 @@ export {
 	readDirectoryRecursive,
 	mapFilesToContentInBytes,
 	getDirectoryOfFile,
+	directoryExists,
 } from "@utilities/fileSystem.utils";


### PR DESCRIPTION
## Description
In past pull requests, we modified the createDirectory to throw a message when the directory exists.
It works for us to create a directory for the "pull-resources-from-the-server" feature, but it doesn't fit when we should download starlarkLSP, because in case we want to download starlarkLSP, and we don't have locally the LSP file, but we do have the directory, we still would like to download the LSP file into the directory.

In other words:
When we had Starlark only - we used createDirectory and if the directory existed, it didn't matter, because even if the folder existed, we knew that the Starlark file was missing and we should download it to the directory.
*Directory Exist -> no error thrown, don't care*

 2. When we developed DownloadResources - if the directory exists - it matters because if it already exists, we won't like to override it, since it probably has the old files.
*Directory Exist -> error should be thrown, care because won't like to override the existing folder.*

When we changed the createDirectory function to: Directory Exist -> error should be thrown, Starlark couldn't work in case: we don't have the LSP file, but we do have the directory.

I hope that explains the issue I created in the latest PR of Download Resources, and asking to fix it in this PR.

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [ ] Notify only when user attention is needed, otherwise log to console.
  - [ ] Notifications: short description with context identifiers (e.g. id of the manipulated entity).
  - [ ] Logs: full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [ ] If you're not sure what is the proper behavior, consult with the product team.
- [ ] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [ ] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sorting, fitlering, etc.), not by services, to maintain a clean MVC architecture.
- [ ] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [ ] Avoid using `!important` in CSS where possible.
- [ ] Use memoization for class calculations.
- [ ] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
