### PR TITLE
feat (UI-228): react split pane

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 
 vscode-react/build*
 vscode-react/index.html
+vscode-react/stats.html
 src/autokitteh*
 
 package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -15769,6 +15769,15 @@
 			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
 			"dev": true
 		},
+		"node_modules/split-pane-react": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/split-pane-react/-/split-pane-react-0.1.3.tgz",
+			"integrity": "sha512-+50VW9+1yglO+2AgL7MhvJ3UazYTqJ4LBJTs44od/D/CTvsqQ9xoDlaHdIpJ5SbXxUqBxvdJD5zoIVnoG+mNTg==",
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
 		"node_modules/split2": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -17757,6 +17766,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-popper": "^2.3.0",
+				"split-pane-react": "^0.1.3",
 				"tailwind-merge": "^2.2.1",
 				"vite-plugin-svgr": "^4.2.0"
 			},

--- a/vscode-react/package.json
+++ b/vscode-react/package.json
@@ -22,6 +22,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-popper": "^2.3.0",
+		"split-pane-react": "^0.1.3",
 		"tailwind-merge": "^2.2.1",
 		"vite-plugin-svgr": "^4.2.0"
 	},

--- a/vscode-react/src/app.css
+++ b/vscode-react/src/app.css
@@ -9,3 +9,7 @@ main {
 	align-items: flex-start;
 	height: 100%;
 }
+
+.react-split__pane {
+	overflow-y: auto !important;
+}

--- a/vscode-react/src/app.tsx
+++ b/vscode-react/src/app.tsx
@@ -80,7 +80,7 @@ function App() {
 						</div>
 					</div>
 					<AppStateProvider>
-						<div className="h-screen">
+						<div className="h-[calc(100vh-5vh)]">
 							<SplitPane
 								split="horizontal"
 								sizes={sizes}

--- a/vscode-react/src/app.tsx
+++ b/vscode-react/src/app.tsx
@@ -10,6 +10,8 @@ import { useIncomingMessageHandler } from "@react-hooks";
 import { AKDeployments, AKSessions } from "@react-sections";
 import { sendMessage } from "@react-utilities";
 import "./app.css";
+import SplitPane from "split-pane-react";
+import "split-pane-react/esm/themes/default.css";
 
 function App() {
 	const [projectName, setProjectName] = useState<string | undefined>();
@@ -23,6 +25,7 @@ function App() {
 		setThemeVisualType,
 		setResourcesDir,
 	});
+	const [sizes, setSizes] = useState<(number | string)[]>(["100%", "100%"]);
 
 	return (
 		<main>
@@ -77,8 +80,16 @@ function App() {
 						</div>
 					</div>
 					<AppStateProvider>
-						<AKDeployments />
-						<AKSessions />
+						<div className="h-screen">
+							<SplitPane split="horizontal" sizes={sizes} onChange={setSizes} sashRender={() => <div />}>
+								<div>
+									<AKDeployments height={sizes[0]} />
+								</div>
+								<div>
+									<AKSessions height={sizes[1]} />
+								</div>
+							</SplitPane>
+						</div>
 					</AppStateProvider>
 				</div>
 			) : (

--- a/vscode-react/src/app.tsx
+++ b/vscode-react/src/app.tsx
@@ -81,7 +81,12 @@ function App() {
 					</div>
 					<AppStateProvider>
 						<div className="h-screen">
-							<SplitPane split="horizontal" sizes={sizes} onChange={setSizes} sashRender={() => <div />}>
+							<SplitPane
+								split="horizontal"
+								sizes={sizes}
+								onChange={setSizes}
+								sashRender={() => <hr className="bg-vscode-editor-background" />}
+							>
 								<div>
 									<AKDeployments height={sizes[0]} />
 								</div>

--- a/vscode-react/src/app.tsx
+++ b/vscode-react/src/app.tsx
@@ -25,7 +25,7 @@ function App() {
 		setThemeVisualType,
 		setResourcesDir,
 	});
-	const [sizes, setSizes] = useState<(number | string)[]>(["100%", "100%"]);
+	const [sizes, setSizes] = useState<(number | string)[]>(["50%", "50%"]);
 
 	return (
 		<main>
@@ -80,7 +80,7 @@ function App() {
 						</div>
 					</div>
 					<AppStateProvider>
-						<div className="h-[calc(100vh-5vh)]">
+						<div className="h-[calc(100vh-6vh)]">
 							<SplitPane
 								split="horizontal"
 								sizes={sizes}

--- a/vscode-react/src/app.tsx
+++ b/vscode-react/src/app.tsx
@@ -85,7 +85,7 @@ function App() {
 								split="horizontal"
 								sizes={sizes}
 								onChange={setSizes}
-								sashRender={() => <hr className="bg-vscode-editor-background" />}
+								sashRender={() => <hr className="bg-vscode-editor-background h-3" />}
 							>
 								<div>
 									<AKDeployments height={sizes[0]} />

--- a/vscode-react/src/components/AKTable/aKTableHeaderCell.component.tsx
+++ b/vscode-react/src/components/AKTable/aKTableHeaderCell.component.tsx
@@ -2,8 +2,14 @@ import React, { ReactNode } from "react";
 
 interface AKTableHeaderCellProps {
 	children: ReactNode;
+	className?: string;
+	colSpan?: number;
 }
 
-export const AKTableHeaderCell = ({ children }: AKTableHeaderCellProps) => {
-	return <th>{children}</th>;
+export const AKTableHeaderCell = ({ children, className, colSpan }: AKTableHeaderCellProps) => {
+	return (
+		<th className={className} colSpan={colSpan}>
+			{children}
+		</th>
+	);
 };

--- a/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
+++ b/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKDeploymentTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-2">
+		<AKTableHeader classes="sticky top-8 z-40">
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.statuses.stopped")}</AKTableHeaderCell>

--- a/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
+++ b/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKDeploymentTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-0">
+		<AKTableHeader classes="sticky top-2">
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.statuses.stopped")}</AKTableHeaderCell>

--- a/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
+++ b/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKDeploymentTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-8 z-40">
+		<AKTableHeader classes="sticky top-12 z-50">
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.statuses.stopped")}</AKTableHeaderCell>

--- a/vscode-react/src/components/aKSessionTableHeader.component.tsx
+++ b/vscode-react/src/components/aKSessionTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKSessionsTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-8 z-50">
+		<AKTableHeader classes="sticky top-12 z-50">
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.sessionId")}</AKTableHeaderCell>

--- a/vscode-react/src/components/aKSessionTableHeader.component.tsx
+++ b/vscode-react/src/components/aKSessionTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKSessionsTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-0">
+		<AKTableHeader classes="sticky top-2">
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.sessionId")}</AKTableHeaderCell>

--- a/vscode-react/src/components/aKSessionTableHeader.component.tsx
+++ b/vscode-react/src/components/aKSessionTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKSessionsTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-2">
+		<AKTableHeader classes="sticky top-8 z-50">
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.sessionId")}</AKTableHeaderCell>

--- a/vscode-react/src/components/akMonacoEditorModal.component.tsx
+++ b/vscode-react/src/components/akMonacoEditorModal.component.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { Editor } from "@monaco-editor/react";
 import { AKModal } from "@react-components";
 
-export const AKMonacoEditorModal = ({ hideModal, content }: { hideModal: () => void; content?: string }) => (
-	<AKModal wrapperClasses={["!bg-transparent"]} classes={["bg-[#00000050]", "rounded-none"]}>
-		<div className="flex justify-end cursor-pointer text-white font-extrabold pt-8 text-xl" onClick={() => hideModal()}>
+export const AKMonacoEditorModal = ({ onCloseClicked, content }: { onCloseClicked: () => void; content?: string }) => (
+	<AKModal wrapperClasses={["!bg-transparent z-50"]} classes={["bg-[#00000050]", "rounded-none"]}>
+		<div
+			className="flex justify-end cursor-pointer text-white font-extrabold pt-8 text-xl"
+			onClick={() => onCloseClicked()}
+		>
 			X
 		</div>
 		<div className="m-auto">

--- a/vscode-react/src/components/akMonacoEditorModal.component.tsx
+++ b/vscode-react/src/components/akMonacoEditorModal.component.tsx
@@ -2,18 +2,9 @@ import React from "react";
 import { Editor } from "@monaco-editor/react";
 import { AKModal } from "@react-components";
 
-export const AKMonacoEditorModal = ({
-	setModal,
-	content,
-}: {
-	setModal: (isDisplayed: boolean) => void;
-	content?: string;
-}) => (
+export const AKMonacoEditorModal = ({ hideModal, content }: { hideModal: () => void; content?: string }) => (
 	<AKModal wrapperClasses={["!bg-transparent"]} classes={["bg-[#00000050]", "rounded-none"]}>
-		<div
-			className="flex justify-end cursor-pointer text-white font-extrabold pt-8 text-xl"
-			onClick={() => setModal(false)}
-		>
+		<div className="flex justify-end cursor-pointer text-white font-extrabold pt-8 text-xl" onClick={() => hideModal()}>
 			X
 		</div>
 		<div className="m-auto">

--- a/vscode-react/src/sections/aKDeployments.section.tsx
+++ b/vscode-react/src/sections/aKDeployments.section.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { translate } from "@i18n";
 import { DeploymentSectionViewModel } from "@models";
 import { AKDeploymentTableBody, AKDeploymentTableHeader } from "@react-components";
-import { AKTable, AKTableMessage } from "@react-components/AKTable";
+import { AKTable, AKTableHeader, AKTableHeaderCell, AKTableMessage } from "@react-components/AKTable";
 import { useAppState } from "@react-context";
 import { useIncomingMessageHandler } from "@react-hooks";
 import { Deployment } from "@type/models";
@@ -36,11 +36,12 @@ export const AKDeployments = ({ height }: { height: string | number }) => {
 
 	return (
 		<div className="mt-4" style={{ height }}>
-			<div className="flex items-baseline">
-				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.deployments.tableTitle")}</h1>
-				<div className="ml-1 text-lg font-extralight">({totalDeployments})</div>
-			</div>
 			<AKTable>
+				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
+					<AKTableHeaderCell className="text-lg font-extralight" colSpan={8}>
+						{`${translate().t("reactApp.deployments.tableTitle")} (${totalDeployments})`}
+					</AKTableHeaderCell>
+				</AKTableHeader>
 				<AKDeploymentTableHeader />
 				<AKDeploymentTableBody deployments={deployments} />
 			</AKTable>

--- a/vscode-react/src/sections/aKDeployments.section.tsx
+++ b/vscode-react/src/sections/aKDeployments.section.tsx
@@ -37,7 +37,7 @@ export const AKDeployments = ({ height }) => {
 	console.log("height deployments", height);
 
 	return (
-		<div className="mt-4" style={{ height: `${height + 200}px` }}>
+		<div className="mt-4" style={{ height }}>
 			<div className="flex items-baseline">
 				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.deployments.tableTitle")}</h1>
 				<div className="ml-1 text-lg font-extralight">({totalDeployments})</div>

--- a/vscode-react/src/sections/aKDeployments.section.tsx
+++ b/vscode-react/src/sections/aKDeployments.section.tsx
@@ -7,7 +7,7 @@ import { useAppState } from "@react-context";
 import { useIncomingMessageHandler } from "@react-hooks";
 import { Deployment } from "@type/models";
 
-export const AKDeployments = ({ height }) => {
+export const AKDeployments = ({ height }: { height: string | number }) => {
 	const [deploymentsSection, setDeploymentsSection] = useState<DeploymentSectionViewModel>();
 	const [isLoading, setIsLoading] = useState(true);
 	const [totalDeployments, setTotalDeployments] = useState<number>();
@@ -33,8 +33,6 @@ export const AKDeployments = ({ height }) => {
 			setDeployments(deploymentsSection?.deployments);
 		}
 	}, [deploymentsSection]);
-
-	console.log("height deployments", height);
 
 	return (
 		<div className="mt-4" style={{ height }}>

--- a/vscode-react/src/sections/aKDeployments.section.tsx
+++ b/vscode-react/src/sections/aKDeployments.section.tsx
@@ -35,10 +35,10 @@ export const AKDeployments = ({ height }: { height: string | number }) => {
 	}, [deploymentsSection]);
 
 	return (
-		<div className="mt-4" style={{ height }}>
+		<div style={{ height }}>
 			<AKTable>
 				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
-					<AKTableHeaderCell className="text-lg font-extralight" colSpan={8}>
+					<AKTableHeaderCell className="text-lg font-extralight pt-5" colSpan={8}>
 						{`${translate().t("reactApp.deployments.tableTitle")} (${totalDeployments})`}
 					</AKTableHeaderCell>
 				</AKTableHeader>

--- a/vscode-react/src/sections/aKDeployments.section.tsx
+++ b/vscode-react/src/sections/aKDeployments.section.tsx
@@ -7,7 +7,7 @@ import { useAppState } from "@react-context";
 import { useIncomingMessageHandler } from "@react-hooks";
 import { Deployment } from "@type/models";
 
-export const AKDeployments = () => {
+export const AKDeployments = ({ height }) => {
 	const [deploymentsSection, setDeploymentsSection] = useState<DeploymentSectionViewModel>();
 	const [isLoading, setIsLoading] = useState(true);
 	const [totalDeployments, setTotalDeployments] = useState<number>();
@@ -34,8 +34,10 @@ export const AKDeployments = () => {
 		}
 	}, [deploymentsSection]);
 
+	console.log("height deployments", height);
+
 	return (
-		<div className="mt-4 h-[43vh] overflow-y-auto overflow-x-hidden">
+		<div className="mt-4" style={{ height: `${height + 200}px` }}>
 			<div className="flex items-baseline">
 				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.deployments.tableTitle")}</h1>
 				<div className="ml-1 text-lg font-extralight">({totalDeployments})</div>

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -5,6 +5,7 @@ import { AKMonacoEditorModal, AKOverlay, AKSessionsTableHeader } from "@react-co
 import { AKSessionsTableBody } from "@react-components/aKSessionTableBody.component";
 import { AKTable, AKTableMessage } from "@react-components/AKTable";
 import { useCloseOnEscape, useIncomingMessageHandler, useForceRerender } from "@react-hooks";
+import { createPortal } from "react-dom";
 
 export const AKSessions = ({ height }: { height: string | number }) => {
 	const [inputsModalVisible, setInputsModalVisible] = useState(false);
@@ -44,8 +45,8 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 			<AKTable>
 				<AKSessionsTableHeader />
 				<AKSessionsTableBody
-					displayInputsModal={displayInputsModal}
 					sessions={sessions}
+					displayInputsModal={displayInputsModal}
 					selectedSession={selectedSession}
 					setSelectedSession={setSelectedSession}
 				/>
@@ -59,7 +60,11 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 			)}
 			<AKOverlay isVisibile={inputsModalVisible} onOverlayClick={() => setInputsModalVisible(false)} />
 
-			{inputsModalVisible && <AKMonacoEditorModal content={sessionInputs} setModal={setInputsModalVisible} />}
+			{inputsModalVisible &&
+				createPortal(
+					<AKMonacoEditorModal content={sessionInputs} hideModal={() => setInputsModalVisible(false)} />,
+					document.body
+				)}
 		</div>
 	);
 };

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -3,7 +3,7 @@ import { translate } from "@i18n";
 import { SessionSectionViewModel } from "@models/views";
 import { AKMonacoEditorModal, AKOverlay, AKSessionsTableHeader } from "@react-components";
 import { AKSessionsTableBody } from "@react-components/aKSessionTableBody.component";
-import { AKTable, AKTableMessage } from "@react-components/AKTable";
+import { AKTable, AKTableHeader, AKTableHeaderCell, AKTableMessage } from "@react-components/AKTable";
 import { useCloseOnEscape, useIncomingMessageHandler, useForceRerender } from "@react-hooks";
 import { createPortal } from "react-dom";
 
@@ -38,11 +38,16 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 
 	return (
 		<div className="mt-4" style={{ height }}>
-			<div className="flex items-baseline">
+			{/* <div className="flex items-baseline sticky top-0 z-20 bg-vscode-editor-background">
 				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.sessions.tableTitle")}</h1>
 				<div className="ml-1 text-lg font-extralight">({totalSessions})</div>
-			</div>
+			</div> */}
 			<AKTable>
+				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
+					<AKTableHeaderCell className="text-lg font-extralight" colSpan={8}>
+						{`${translate().t("reactApp.sessions.tableTitle")} (${totalSessions})`}
+					</AKTableHeaderCell>
+				</AKTableHeader>
 				<AKSessionsTableHeader />
 				<AKSessionsTableBody
 					sessions={sessions}

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -6,7 +6,7 @@ import { AKSessionsTableBody } from "@react-components/aKSessionTableBody.compon
 import { AKTable, AKTableMessage } from "@react-components/AKTable";
 import { useCloseOnEscape, useIncomingMessageHandler, useForceRerender } from "@react-hooks";
 
-export const AKSessions = () => {
+export const AKSessions = ({ height }) => {
 	const [inputsModalVisible, setInputsModalVisible] = useState(false);
 
 	const [isLoading, setIsLoading] = useState(true);
@@ -36,7 +36,7 @@ export const AKSessions = () => {
 	};
 
 	return (
-		<div className="mt-4 h-[43vh] overflow-y-auto overflow-x-hidden">
+		<div className="mt-4" style={{ height: height }}>
 			<div className="flex items-baseline">
 				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.sessions.tableTitle")}</h1>
 				<div className="ml-1 text-lg font-extralight">({totalSessions})</div>

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -36,7 +36,7 @@ export const AKSessions = ({ height }) => {
 	};
 
 	return (
-		<div className="mt-4" style={{ height: height }}>
+		<div className="mt-4" style={{ height }}>
 			<div className="flex items-baseline">
 				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.sessions.tableTitle")}</h1>
 				<div className="ml-1 text-lg font-extralight">({totalSessions})</div>

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -6,7 +6,7 @@ import { AKSessionsTableBody } from "@react-components/aKSessionTableBody.compon
 import { AKTable, AKTableMessage } from "@react-components/AKTable";
 import { useCloseOnEscape, useIncomingMessageHandler, useForceRerender } from "@react-hooks";
 
-export const AKSessions = ({ height }) => {
+export const AKSessions = ({ height }: { height: string | number }) => {
 	const [inputsModalVisible, setInputsModalVisible] = useState(false);
 
 	const [isLoading, setIsLoading] = useState(true);

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -1,17 +1,13 @@
 import { useEffect, useState } from "react";
 import { translate } from "@i18n";
 import { SessionSectionViewModel } from "@models/views";
-import { AKMonacoEditorModal, AKOverlay, AKSessionsTableHeader } from "@react-components";
+import { AKSessionsTableHeader } from "@react-components";
 import { AKSessionsTableBody } from "@react-components/aKSessionTableBody.component";
 import { AKTable, AKTableHeader, AKTableHeaderCell, AKTableMessage } from "@react-components/AKTable";
-import { useCloseOnEscape, useIncomingMessageHandler, useForceRerender } from "@react-hooks";
-import { createPortal } from "react-dom";
+import { useIncomingMessageHandler, useForceRerender } from "@react-hooks";
 
 export const AKSessions = ({ height }: { height: string | number }) => {
-	const [inputsModalVisible, setInputsModalVisible] = useState(false);
-
 	const [isLoading, setIsLoading] = useState(true);
-	const [sessionInputs, setSessionInputs] = useState<string>();
 	const [sessionsSection, setSessionsSection] = useState<SessionSectionViewModel | undefined>();
 	const [selectedSession, setSelectedSession] = useState<string | undefined>("");
 
@@ -28,26 +24,19 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 		}
 	}, [sessions]);
 
-	useCloseOnEscape(() => setInputsModalVisible(false));
 	useForceRerender();
-
-	const displayInputsModal = (sessionInputs: string) => {
-		setSessionInputs(sessionInputs);
-		setInputsModalVisible(true);
-	};
 
 	return (
 		<div style={{ height }}>
 			<AKTable>
 				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
-					<AKTableHeaderCell className="text-lg font-extralight pt-5" colSpan={8}>
+					<AKTableHeaderCell className="text-lg font-extralight pt-5" colSpan={4}>
 						{`${translate().t("reactApp.sessions.tableTitle")} (${totalSessions})`}
 					</AKTableHeaderCell>
 				</AKTableHeader>
 				<AKSessionsTableHeader />
 				<AKSessionsTableBody
 					sessions={sessions}
-					displayInputsModal={displayInputsModal}
 					selectedSession={selectedSession}
 					setSelectedSession={setSelectedSession}
 				/>
@@ -59,13 +48,6 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 			{sessions && sessions.length === 0 && (
 				<AKTableMessage>{translate().t("reactApp.sessions.noSessionsFound")}</AKTableMessage>
 			)}
-			<AKOverlay isVisibile={inputsModalVisible} onOverlayClick={() => setInputsModalVisible(false)} />
-
-			{inputsModalVisible &&
-				createPortal(
-					<AKMonacoEditorModal content={sessionInputs} hideModal={() => setInputsModalVisible(false)} />,
-					document.body
-				)}
 		</div>
 	);
 };

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -37,14 +37,10 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 	};
 
 	return (
-		<div className="mt-4" style={{ height }}>
-			{/* <div className="flex items-baseline sticky top-0 z-20 bg-vscode-editor-background">
-				<h1 className="flex text-lg font-extralight mb-2">{translate().t("reactApp.sessions.tableTitle")}</h1>
-				<div className="ml-1 text-lg font-extralight">({totalSessions})</div>
-			</div> */}
+		<div style={{ height }}>
 			<AKTable>
 				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
-					<AKTableHeaderCell className="text-lg font-extralight" colSpan={8}>
+					<AKTableHeaderCell className="text-lg font-extralight pt-5" colSpan={8}>
 						{`${translate().t("reactApp.sessions.tableTitle")} (${totalSessions})`}
 					</AKTableHeaderCell>
 				</AKTableHeader>


### PR DESCRIPTION
## Description
Allow users to move the border between sessions and deployments split.

Demonstration:

https://github.com/autokitteh/vscode-extension/assets/7413072/ddcd2316-fb9a-4ec9-9aae-cacbf284fd0f


## Linear Ticket
https://linear.app/autokitteh/issue/UI-228/add-ability-of-pane-pull-between-sessions-and-deployments

## What type of PR is this? (check all applicable)

- [x] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [x] Notify only when user attention is needed, otherwise log to console.
  - [x] Notifications: short description with context identifiers (e.g. id of the manipulated entity).
  - [x] Logs: full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [x] If you're not sure what is the proper behavior, consult with the product team.
- [x] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [x] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sorting, fitlering, etc.), not by services, to maintain a clean MVC architecture.
- [x] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [x] Avoid using `!important` in CSS where possible.
- [x] Use memoization for class calculations.
- [x] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
