### PR TITLE
fix: poppers and overlays weren't displayed properly because of the split-pane feature

### DIFF
--- a/vscode-react/src/components/aKDeploymentTableBody.component.tsx
+++ b/vscode-react/src/components/aKDeploymentTableBody.component.tsx
@@ -9,6 +9,7 @@ import { useDeployments } from "@react-hooks";
 import { useIncomingMessageHandler } from "@react-hooks";
 import { getTimePassed, sendMessage } from "@react-utilities";
 import { Deployment, SessionEntrypoint } from "@type/models";
+import { createPortal } from "react-dom";
 
 export const AKDeploymentTableBody = ({ deployments }: { deployments?: Deployment[] }) => {
 	// State Hooks Section
@@ -218,32 +219,36 @@ export const AKDeploymentTableBody = ({ deployments }: { deployments?: Deploymen
 							onClick={(event) => showDeleteDeploymentPopper(event, deployment)}
 						></div>
 					</div>
-
-					<AKOverlay
-						isVisibile={index === 0 && (modalName === "deploymentDelete" || modalName === "deploymentExecute")}
-						onOverlayClick={() => hidePopper()}
-					/>
-					<PopperComponent visible={modalName === "deploymentDelete"} referenceRef={deletePopperElementRef}>
-						<DeletePopper
-							isDeletingInProcess={isDeletingInProcess}
-							onConfirm={() => deleteDeploymentConfirmed()}
-							onDismiss={() => deleteDeploymentDismissed()}
-							translations={deleteDeploymentPopperTranslations}
-						/>
-					</PopperComponent>
-					<PopperComponent visible={modalName === "deploymentExecute"} referenceRef={executePopperElementRef}>
-						<ExecutePopper
-							files={files!}
-							functions={functions!}
-							selectedFile={selectedFile}
-							selectedFunction={selectedFunction}
-							onFileChange={setSelectedFile}
-							onFunctionChange={handleFunctionChange}
-							onStartSession={startSession}
-							onClose={() => hidePopper()}
-							displayedErrors={displayedErrors}
-						/>
-					</PopperComponent>
+					{createPortal(
+						<div>
+							<AKOverlay
+								isVisibile={index === 0 && (modalName === "deploymentDelete" || modalName === "deploymentExecute")}
+								onOverlayClick={() => hidePopper()}
+							/>
+							<PopperComponent visible={modalName === "deploymentDelete"} referenceRef={deletePopperElementRef}>
+								<DeletePopper
+									isDeletingInProcess={isDeletingInProcess}
+									onConfirm={() => deleteDeploymentConfirmed()}
+									onDismiss={() => deleteDeploymentDismissed()}
+									translations={deleteDeploymentPopperTranslations}
+								/>
+							</PopperComponent>
+							<PopperComponent visible={modalName === "deploymentExecute"} referenceRef={executePopperElementRef}>
+								<ExecutePopper
+									files={files!}
+									functions={functions!}
+									selectedFile={selectedFile}
+									selectedFunction={selectedFunction}
+									onFileChange={setSelectedFile}
+									onFunctionChange={handleFunctionChange}
+									onStartSession={startSession}
+									onClose={() => hidePopper()}
+									displayedErrors={displayedErrors}
+								/>
+							</PopperComponent>
+						</div>,
+						document.body
+					)}
 				</AKTableCell>
 			</AKTableRow>
 		))

--- a/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
+++ b/vscode-react/src/components/aKDeploymentTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKDeploymentTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-12 z-50">
+		<AKTableHeader classes="sticky top-12 z-30">
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.deployments.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.statuses.stopped")}</AKTableHeaderCell>

--- a/vscode-react/src/components/aKOverlay.component.tsx
+++ b/vscode-react/src/components/aKOverlay.component.tsx
@@ -5,7 +5,7 @@ type AKOverlayProps = {
 export const AKOverlay = ({ onOverlayClick = () => {}, isVisibile }: AKOverlayProps) =>
 	isVisibile && (
 		<div
-			className="absolute h-screen w-screen top-0 left-0 bg-black opacity-60 z-50"
+			className="absolute h-screen w-screen top-0 left-0 bg-black opacity-50 z-50"
 			onClick={() => onOverlayClick()}
 		></div>
 	);

--- a/vscode-react/src/components/aKOverlay.component.tsx
+++ b/vscode-react/src/components/aKOverlay.component.tsx
@@ -5,7 +5,7 @@ type AKOverlayProps = {
 export const AKOverlay = ({ onOverlayClick = () => {}, isVisibile }: AKOverlayProps) =>
 	isVisibile && (
 		<div
-			className="absolute h-screen w-screen top-0 left-0 bg-black opacity-50 z-20"
+			className="absolute h-screen w-screen top-0 left-0 bg-black opacity-60 z-50"
 			onClick={() => onOverlayClick()}
 		></div>
 	);

--- a/vscode-react/src/components/aKPopper.component.tsx
+++ b/vscode-react/src/components/aKPopper.component.tsx
@@ -35,7 +35,8 @@ export const PopperComponent: React.FC<PopperProps> = ({ visible, children, refe
 	}, [visible]);
 
 	// eslint-disable-next-line max-len
-	const popperClasses = `flex-col z-50 bg-vscode-editor-background text-vscode-foreground border border-gray-300 p-4 rounded-lg shadow-lg`;
+	const popperClasses =
+		"flex-col z-50 bg-vscode-editor-background text-vscode-foreground border border-gray-300 p-4 rounded-lg shadow-lg";
 
 	return (
 		<>

--- a/vscode-react/src/components/aKPopper.component.tsx
+++ b/vscode-react/src/components/aKPopper.component.tsx
@@ -34,7 +34,6 @@ export const PopperComponent: React.FC<PopperProps> = ({ visible, children, refe
 		}
 	}, [visible]);
 
-	// eslint-disable-next-line max-len
 	const popperClasses =
 		"flex-col z-50 bg-vscode-editor-background text-vscode-foreground border border-gray-300 p-4 rounded-lg shadow-lg";
 

--- a/vscode-react/src/components/aKPopper.component.tsx
+++ b/vscode-react/src/components/aKPopper.component.tsx
@@ -35,7 +35,7 @@ export const PopperComponent: React.FC<PopperProps> = ({ visible, children, refe
 	}, [visible]);
 
 	// eslint-disable-next-line max-len
-	const popperClasses = `flex-col z-30 bg-vscode-editor-background text-vscode-foreground border border-gray-300 p-4 rounded-lg shadow-lg`;
+	const popperClasses = `flex-col z-50 bg-vscode-editor-background text-vscode-foreground border border-gray-300 p-4 rounded-lg shadow-lg`;
 
 	return (
 		<>

--- a/vscode-react/src/components/aKSessionTableBody.component.tsx
+++ b/vscode-react/src/components/aKSessionTableBody.component.tsx
@@ -167,20 +167,24 @@ export const AKSessionsTableBody = ({
 								}
 								onClick={(event) => displaySessionDeletePopper(event, session)}
 							></div>
+							{createPortal(
+								<div>
+									<AKOverlay
+										isVisibile={modalName === "sessionDelete" && index === 0}
+										onOverlayClick={() => hidePopper()}
+									/>
 
-							<AKOverlay
-								isVisibile={modalName === "sessionDelete" && index === 0}
-								onOverlayClick={() => hidePopper()}
-							/>
-
-							<PopperComponent visible={modalName === "sessionDelete"} referenceRef={deletePopperElementRef}>
-								<DeletePopper
-									isDeletingInProcess={isDeletingInProcess}
-									onConfirm={() => deleteSessionConfirmed()}
-									onDismiss={() => deleteSessionDismissed()}
-									translations={deleteSessionPopperTranslations}
-								/>
-							</PopperComponent>
+									<PopperComponent visible={modalName === "sessionDelete"} referenceRef={deletePopperElementRef}>
+										<DeletePopper
+											isDeletingInProcess={isDeletingInProcess}
+											onConfirm={() => deleteSessionConfirmed()}
+											onDismiss={() => deleteSessionDismissed()}
+											translations={deleteSessionPopperTranslations}
+										/>
+									</PopperComponent>
+								</div>,
+								document.body
+							)}
 						</AKTableCell>
 					</AKTableRow>
 				))}

--- a/vscode-react/src/components/aKSessionTableHeader.component.tsx
+++ b/vscode-react/src/components/aKSessionTableHeader.component.tsx
@@ -4,7 +4,7 @@ import { AKTableHeader, AKTableHeaderCell } from "@react-components/AKTable";
 
 export const AKSessionsTableHeader: React.FC = () => {
 	return (
-		<AKTableHeader classes="sticky top-12 z-50">
+		<AKTableHeader classes="sticky top-12 z-30">
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.time")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.status")}</AKTableHeaderCell>
 			<AKTableHeaderCell>{translate().t("reactApp.sessions.sessionId")}</AKTableHeaderCell>

--- a/vscode-react/src/sections/aKDeployments.section.tsx
+++ b/vscode-react/src/sections/aKDeployments.section.tsx
@@ -37,7 +37,7 @@ export const AKDeployments = ({ height }: { height: string | number }) => {
 	return (
 		<div style={{ height }}>
 			<AKTable>
-				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
+				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-30">
 					<AKTableHeaderCell className="text-lg font-extralight pt-5" colSpan={8}>
 						{`${translate().t("reactApp.deployments.tableTitle")} (${totalDeployments})`}
 					</AKTableHeaderCell>

--- a/vscode-react/src/sections/aKSessions.section.tsx
+++ b/vscode-react/src/sections/aKSessions.section.tsx
@@ -29,7 +29,7 @@ export const AKSessions = ({ height }: { height: string | number }) => {
 	return (
 		<div style={{ height }}>
 			<AKTable>
-				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-40">
+				<AKTableHeader classes="bg-vscode-editor-background sticky top-0 h-8 text-left z-30">
 					<AKTableHeaderCell className="text-lg font-extralight pt-5" colSpan={4}>
 						{`${translate().t("reactApp.sessions.tableTitle")} (${totalSessions})`}
 					</AKTableHeaderCell>


### PR DESCRIPTION
## Description
Since the deployments & sessions tables were locked inside the new panes for the main screen, we had to set-up the z-index properties for them, send them to the top level with `createPortal`.