### PR TITLE
fix: get session log record type by the new structure from the ak backend

### DIFF
--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -48,5 +48,5 @@
 	"projectPathCopiedError": "Error copying project path to clipboard for project: {{projectName}}",
 	"projectPathCopiedErrorEnriched": "Error copying project path to clipboard - project: {{projectName}}, error: {{error}}",
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
-	"sessionLogRecordMultipleProps": "Session log record type not found: {{props}}"
+	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}"
 }

--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -48,5 +48,5 @@
 	"projectPathCopiedError": "Error copying project path to clipboard for project: {{projectName}}",
 	"projectPathCopiedErrorEnriched": "Error copying project path to clipboard - project: {{projectName}}, error: {{error}}",
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
-	"sessionLogRecordMultipleProps": "More than one session log record type found: {{props}}"
+	"sessionLogRecordMultipleProps": "Session log record type not found: {{props}}"
 }

--- a/src/models/sessionLogRecord.model.ts
+++ b/src/models/sessionLogRecord.model.ts
@@ -24,7 +24,7 @@ export class SessionLogRecord {
 		if (!logRecordType) {
 			LoggerService.error(
 				namespaces.sessionsHistory,
-				translate().t("errors.sessionLogRecordMultipleProps", { props: Object.keys(props).join(", ") })
+				translate().t("errors.sessionLogRecordTypeNotFound", { props: Object.keys(props).join(", ") })
 			);
 			return;
 		}

--- a/src/models/sessionLogRecord.model.ts
+++ b/src/models/sessionLogRecord.model.ts
@@ -19,14 +19,15 @@ export class SessionLogRecord {
 	constructor(logRecord: ProtoSessionLogRecord) {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { t, ...props } = logRecord;
-		if (Object.keys(props).length > 1) {
+		const logRecordType = this.getLogRecordType(props);
+
+		if (!logRecordType) {
 			LoggerService.error(
 				namespaces.sessionsHistory,
 				translate().t("errors.sessionLogRecordMultipleProps", { props: Object.keys(props).join(", ") })
 			);
 			return;
 		}
-		const logRecordType = Object.keys(props)[0] as SessionLogRecordType;
 
 		switch (logRecordType) {
 			case SessionLogRecordType.callAttemptStart:
@@ -51,6 +52,16 @@ export class SessionLogRecord {
 		if (logRecordType !== SessionLogRecordType.callAttemptStart) {
 			this.dateTime = convertTimestampToDate(logRecord.t);
 		}
+	}
+
+	private getLogRecordType(props: { [key: string]: any }): SessionLogRecordType | undefined {
+		const keys = Object.keys(props);
+		for (const key of keys) {
+			if (key in SessionLogRecordType) {
+				return key as SessionLogRecordType;
+			}
+		}
+		return undefined;
 	}
 
 	private handleStateRecord(logRecord: ProtoSessionLogRecord) {


### PR DESCRIPTION
## Description
The backend structure of the session log record has been changed, now we don't have only one key per session log, but `processId` also.
Because of this, we have to find the needed key and not assume it's the only one and located at the first index of props.

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
