### PR TITLE
feat: disable session auto-select the last one on change (UI-237)

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -35,6 +35,7 @@ export class ProjectController {
 	private filterSessionsState?: string;
 	private hasDisplayedError: Map<ProjectRecurringErrorMessages, boolean> = new Map();
 	private selectedFirstSessionPerDeployment: Map<string, boolean> = new Map();
+	private selectedSessionPerDeployment: Map<string, string> = new Map();
 
 	constructor(
 		projectView: IProjectView,
@@ -259,7 +260,14 @@ export class ProjectController {
 			});
 
 			this.displaySessionLogs(sessions![0].sessionId);
-			this.selectedFirstSessionPerDeployment.set(this.selectedDeploymentId, true);
+			this.selectedSessionPerDeployment.set(this.selectedDeploymentId, sessions![0].sessionId);
+		} else if (sessions?.length && this.selectedSessionPerDeployment.get(this.selectedDeploymentId)) {
+			this.view.update({
+				type: MessageType.selectSession,
+				payload: this.selectedSessionPerDeployment.get(this.selectedDeploymentId),
+			});
+
+			this.displaySessionLogs(this.selectedSessionPerDeployment.get(this.selectedDeploymentId)!);
 		}
 	}
 
@@ -337,6 +345,8 @@ export class ProjectController {
 	async displaySessionLogs(sessionId: string): Promise<void> {
 		this.stopInterval(ProjectIntervalTypes.sessionHistory);
 		LoggerService.clearOutputChannel(channels.appOutputSessionsLogName);
+
+		this.selectedSessionPerDeployment.set(this.selectedDeploymentId!, sessionId);
 
 		this.selectedSessionId = sessionId;
 		this.initSessionLogsDisplay(sessionId);
@@ -648,10 +658,14 @@ export class ProjectController {
 		});
 
 		this.selectedDeploymentId = startSessionArgs.deploymentId;
+
+		this.selectedSessionPerDeployment.set(this.selectedDeploymentId, sessionId!);
+
 		this.view.update({
 			type: MessageType.selectDeployment,
 			payload: startSessionArgs.deploymentId,
 		});
+
 		this.displaySessionLogs(sessionId!);
 	}
 

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -189,6 +189,9 @@ export class ProjectController {
 	}
 
 	setSessionsStateFilter(filterState: string) {
+		if (this.filterSessionsState === filterState) {
+			return;
+		}
 		this.filterSessionsState = filterState;
 		LoggerService.clearOutputChannel(channels.appOutputSessionsLogName);
 		this.fetchSessions();

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -190,6 +190,7 @@ export class ProjectController {
 
 	setSessionsStateFilter(filterState: string) {
 		this.filterSessionsState = filterState;
+		LoggerService.clearOutputChannel(channels.appOutputSessionsLogName);
 		this.fetchSessions();
 	}
 
@@ -656,22 +657,6 @@ export class ProjectController {
 		}
 		const successMessage = translate().t("sessions.executionSucceed", { sessionId });
 		LoggerService.info(namespaces.projectController, successMessage);
-
-		this.view.update({
-			type: MessageType.selectSession,
-			payload: sessionId,
-		});
-
-		this.selectedDeploymentId = startSessionArgs.deploymentId;
-
-		this.selectedSessionPerDeployment.set(this.selectedDeploymentId, sessionId!);
-
-		this.view.update({
-			type: MessageType.selectDeployment,
-			payload: startSessionArgs.deploymentId,
-		});
-
-		this.displaySessionLogs(sessionId!);
 	}
 
 	async deactivateDeployment(deploymentId: string) {

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -886,6 +886,18 @@ export class ProjectController {
 
 			return;
 		}
+
+		if (this.selectedSessionId === sessionId) {
+			let sessionIndex = this.sessions?.findIndex((session) => session.sessionId === sessionId);
+
+			if (sessionIndex === this.sessions!.length - 1) {
+				sessionIndex = this.sessions!.length - 3;
+			}
+
+			const selectedSessionId = this.sessions?.[sessionIndex! + 1]?.sessionId;
+			this.displaySessionLogs(selectedSessionId!);
+		}
+
 		this.view.update({
 			type: MessageType.deleteSessionResponse,
 		});

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -34,6 +34,7 @@ export class ProjectController {
 	private selectedSessionId?: string;
 	private filterSessionsState?: string;
 	private hasDisplayedError: Map<ProjectRecurringErrorMessages, boolean> = new Map();
+	private selectedFirstSessionPerDeployment: Map<string, boolean> = new Map();
 
 	constructor(
 		projectView: IProjectView,
@@ -246,13 +247,19 @@ export class ProjectController {
 			payload: sessionsViewObject,
 		});
 
-		if (sessions?.length) {
+		this.view.update({
+			type: MessageType.selectDeployment,
+			payload: this.selectedDeploymentId,
+		});
+
+		if (sessions?.length && !this.selectedFirstSessionPerDeployment.get(this.selectedDeploymentId)) {
 			this.view.update({
 				type: MessageType.selectSession,
 				payload: sessions[0].sessionId,
 			});
 
 			this.displaySessionLogs(sessions![0].sessionId);
+			this.selectedFirstSessionPerDeployment.set(this.selectedDeploymentId, true);
 		}
 	}
 

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -34,7 +34,6 @@ export class ProjectController {
 	private selectedSessionId?: string;
 	private filterSessionsState?: string;
 	private hasDisplayedError: Map<ProjectRecurringErrorMessages, boolean> = new Map();
-	private selectedFirstSessionPerDeployment: Map<string, boolean> = new Map();
 	private selectedSessionPerDeployment: Map<string, string> = new Map();
 
 	constructor(
@@ -253,7 +252,7 @@ export class ProjectController {
 			payload: this.selectedDeploymentId,
 		});
 
-		if (sessions?.length && !this.selectedFirstSessionPerDeployment.get(this.selectedDeploymentId)) {
+		if (sessions?.length && !this.selectedSessionPerDeployment.get(this.selectedDeploymentId)) {
 			this.view.update({
 				type: MessageType.selectSession,
 				payload: sessions[0].sessionId,
@@ -262,12 +261,18 @@ export class ProjectController {
 			this.displaySessionLogs(sessions![0].sessionId);
 			this.selectedSessionPerDeployment.set(this.selectedDeploymentId, sessions![0].sessionId);
 		} else if (sessions?.length && this.selectedSessionPerDeployment.get(this.selectedDeploymentId)) {
-			this.view.update({
-				type: MessageType.selectSession,
-				payload: this.selectedSessionPerDeployment.get(this.selectedDeploymentId),
-			});
+			const isCurrentSelectedSessionDisplayed = sessions.find(
+				(session) => session.sessionId === this.selectedSessionPerDeployment.get(this.selectedDeploymentId!)
+			);
 
-			this.displaySessionLogs(this.selectedSessionPerDeployment.get(this.selectedDeploymentId)!);
+			if (isCurrentSelectedSessionDisplayed) {
+				this.view.update({
+					type: MessageType.selectSession,
+					payload: isCurrentSelectedSessionDisplayed.sessionId,
+				});
+				this.displaySessionLogs(isCurrentSelectedSessionDisplayed?.sessionId!);
+			}
+			LoggerService.clearOutputChannel(channels.appOutputSessionsLogName);
 		}
 	}
 

--- a/src/enums/projectRecurringErrors.enum.ts
+++ b/src/enums/projectRecurringErrors.enum.ts
@@ -1,5 +1,4 @@
 export enum ProjectRecurringErrorMessages {
-	sessionStateConverter,
 	deployments,
 	sessions,
 }

--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -49,6 +49,5 @@
 	"projectPathCopiedErrorEnriched": "Error copying project path to clipboard - project: {{projectName}}, error: {{error}}",
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
 	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}",
-	"internalErrorUpdate": "Internal error, update the extension",
-	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}"
+	"internalErrorUpdate": "Internal error, update the extension"
 }


### PR DESCRIPTION
## Description
In order to avoid selected session change every second in a case when many sessions are coming every second, in our case disabled the latest session selection on sessions change.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-237/sessions-logs-on-load-doesnt-load-well

## Screenshots
https://github.com/autokitteh/vscode-extension/assets/7413072/5f42d588-580b-4cd2-af56-ce2f09010478


## What type of PR is this? (check all applicable)

- [x] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [x] Notify only when user attention is needed, otherwise log to console.
  - [x] Notifications: short description with context identifiers (e.g. id of the manipulated entity).
  - [x] Logs: full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [x] If you're not sure what is the proper behavior, consult with the product team.
- [x] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [x] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sorting, fitlering, etc.), not by services, to maintain a clean MVC architecture.
- [x] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [x] Avoid using `!important` in CSS where possible.
- [x] Use memoization for class calculations.
- [x] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
