### PR TITLE
fix: remove redhat-yaml extension dependency (UI-258)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
 		"@views": "dist/src/views",
 		"@vscommands": "dist/src/vscommands"
 	},
-	"extensionDependencies": [
-		"redhat.vscode-yaml"
-	],
 	"optionalDependencies": {
 		"@rollup/rollup-linux-x64-gnu": "4.6.1"
 	},


### PR DESCRIPTION
## Description
In the last week @ig-ra  paid attention that if he disable all extensions on VSCode except autokitteh, it disables as well.

The issue was that autokitteh had a dependency on the redhat-yaml extension and when it wasn't enabled, autokitteh turned off as well.

We don't need that dependency, since it's nice to have extension with autokitteh, to have yaml files syntax, but it's not a must.

Therefore it should be removed as a dependency.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-258/remove-redhat-yaml-extension-dependency

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).