### PR TITLE
fix: avoid repeating notifications when session history pulled on server down  (UI-259)

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -89,13 +89,18 @@ export class ProjectController {
 
 		if (sessionsError) {
 			if (!this.hasDisplayedError.get(ProjectRecurringErrorMessages.sessionHistory)) {
-				const notificationErrorMessage = translate().t("errors.sessionLogRecordFetchFailed", {
+				const notificationErrorMessage = translate().t("errors.sessionLogRecordFetchFailedShort", {
 					deploymentId: this.selectedDeploymentId,
 				});
 				commands.executeCommand(vsCommands.showErrorMessage, notificationErrorMessage);
 				this.hasDisplayedError.set(ProjectRecurringErrorMessages.sessionHistory, true);
 			}
-			LoggerService.error(namespaces.projectController, (sessionsError as Error).message);
+
+			const logErrorMessage = translate().t("errors.sessionLogRecordFetchFailed", {
+				deploymentId: this.selectedDeploymentId,
+				error: (sessionsError as Error).message,
+			});
+			LoggerService.error(namespaces.projectController, logErrorMessage);
 			return;
 		}
 		if (!sessionHistoryStates?.length || !sessionHistoryStates) {

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -89,7 +89,10 @@ export class ProjectController {
 
 		if (sessionsError) {
 			if (!this.hasDisplayedError.get(ProjectRecurringErrorMessages.sessionHistory)) {
-				commands.executeCommand(vsCommands.showErrorMessage, (sessionsError as Error).message);
+				const notificationErrorMessage = translate().t("errors.sessionLogRecordFetchFailed", {
+					deploymentId: this.selectedDeploymentId,
+				});
+				commands.executeCommand(vsCommands.showErrorMessage, notificationErrorMessage);
 				this.hasDisplayedError.set(ProjectRecurringErrorMessages.sessionHistory, true);
 			}
 			LoggerService.error(namespaces.projectController, (sessionsError as Error).message);

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -88,7 +88,10 @@ export class ProjectController {
 			await SessionsService.getLogRecordsBySessionId(sessionId);
 
 		if (sessionsError) {
-			commands.executeCommand(vsCommands.showErrorMessage, (sessionsError as Error).message);
+			if (!this.hasDisplayedError.get(ProjectRecurringErrorMessages.sessionHistory)) {
+				commands.executeCommand(vsCommands.showErrorMessage, (sessionsError as Error).message);
+				this.hasDisplayedError.set(ProjectRecurringErrorMessages.sessionHistory, true);
+			}
 			LoggerService.error(namespaces.projectController, (sessionsError as Error).message);
 			return;
 		}

--- a/src/enums/projectRecurringErrors.enum.ts
+++ b/src/enums/projectRecurringErrors.enum.ts
@@ -1,4 +1,5 @@
 export enum ProjectRecurringErrorMessages {
 	deployments,
 	sessions,
+	sessionHistory,
 }

--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -49,5 +49,6 @@
 	"projectPathCopiedErrorEnriched": "Error copying project path to clipboard - project: {{projectName}}, error: {{error}}",
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
 	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}",
-	"internalErrorUpdate": "Internal error, update the extension"
+	"internalErrorUpdate": "Internal error, update the extension",
+	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}"
 }

--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -50,5 +50,5 @@
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
 	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}",
 	"internalErrorUpdate": "Internal error, update the extension",
-	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}"
+	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}"	"sessionLogRecordFetchFailed": "Session log fetch failed for deployment ID: {{deploymentId}}"
 }

--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -50,5 +50,7 @@
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
 	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}",
 	"internalErrorUpdate": "Internal error, update the extension",
-	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}"	"sessionLogRecordFetchFailed": "Session log fetch failed for deployment ID: {{deploymentId}}"
+	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}",
+	"sessionLogRecordFetchFailedShort": "Session log fetch failed for deployment ID: {{deploymentId}}",
+	"sessionLogRecordFetchFailed": "Session log fetch failed for deployment ID: {{deploymentId}}, error: {{error}}"
 }

--- a/src/i18n/en/errors.i18n.json
+++ b/src/i18n/en/errors.i18n.json
@@ -50,7 +50,6 @@
 	"sessionStartFailedExtended": "Error running session execution: {{error}} for build id: {{buildId}}",
 	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}",
 	"internalErrorUpdate": "Internal error, update the extension",
-	"sessionStateFilterConversionError": "Session state filter conversion error: {{error}} for state type: {{stateType}}",
 	"sessionLogRecordFetchFailedShort": "Session log fetch failed for deployment ID: {{deploymentId}}",
 	"sessionLogRecordFetchFailed": "Session log fetch failed for deployment ID: {{deploymentId}}, error: {{error}}"
 }


### PR DESCRIPTION
## Description
Session log re-fetching only in one case - when the session is running, there we should disable the repeating notifications displayed to the user.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-259/avoid-repeating-notifications-when-session-log-re-fetching-on-interval

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [x] Notify only when user attention is needed, otherwise log to console.
  - [x] Notifications: short description with context identifiers (e.g. id of the manipulated entity).
  - [ ] Logs: full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [ ] If you're not sure what is the proper behavior, consult with the product team.
- [ ] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [ ] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sorting, fitlering, etc.), not by services, to maintain a clean MVC architecture.
- [ ] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [ ] Avoid using `!important` in CSS where possible.
- [ ] Use memoization for class calculations.
- [ ] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
