### PR TITLE
fix: remove loading state from sessions view

### DIFF
--- a/vscode-react/src/components/sessions/pages/sessionsSection.component.tsx
+++ b/vscode-react/src/components/sessions/pages/sessionsSection.component.tsx
@@ -5,7 +5,6 @@ import { SessionSectionViewModel } from "@models/views";
 import RotateIcon from "@react-assets/icons/rotate.svg?react";
 import { TableMessage } from "@react-components/atoms/table";
 import { SessionsTableBody } from "@react-components/sessions/organisms";
-import { useAppState } from "@react-context";
 import { useIncomingMessageHandler, useForceRerender } from "@react-hooks";
 import { sendMessage } from "@react-utilities";
 
@@ -14,7 +13,6 @@ export const SessionsSection = ({ height }: { height: string | number }) => {
 	const [selectedSession, setSelectedSession] = useState<string | undefined>("");
 	const [stateFilter, setStateFilter] = useState<string>();
 	const [liveTailState, setLiveTailState] = useState<boolean>(true);
-	const [{ delayedLoading }] = useAppState();
 
 	const { sessions, showLiveTail, lastDeployment } = sessionsSection || {};
 
@@ -67,7 +65,7 @@ export const SessionsSection = ({ height }: { height: string | number }) => {
 				}
 			>
 				<div className="flex">{`${translate().t("reactApp.sessions.tableTitle")}`}</div>
-				{!delayedLoading && showLiveTail ? (
+				{showLiveTail ? (
 					<div
 						className="ml-3 w-5 h-5 cursor-pointer"
 						onClick={() => toggleLiveTail()}
@@ -95,10 +93,7 @@ export const SessionsSection = ({ height }: { height: string | number }) => {
 					</select>
 				</div>
 			</div>
-			{delayedLoading && <TableMessage>{translate().t("reactApp.general.loading")}</TableMessage>}
-			{!sessions && !delayedLoading && (
-				<TableMessage>{translate().t("reactApp.sessions.pickDeploymentToShowSessions")}</TableMessage>
-			)}
+			{!sessions && <TableMessage>{translate().t("reactApp.sessions.pickDeploymentToShowSessions")}</TableMessage>}
 			{sessions && sessions.length === 0 && (
 				<TableMessage>{translate().t("reactApp.sessions.noSessionsFound")}</TableMessage>
 			)}

--- a/vscode-react/src/context/appState.context.tsx
+++ b/vscode-react/src/context/appState.context.tsx
@@ -37,7 +37,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
 	useEffect(() => {
 		let timeoutId: NodeJS.Timeout | undefined;
 		if (state.loading) {
-			timeoutId = setTimeout(() => setDelayedLoading(true), 1500);
+			timeoutId = setTimeout(() => setDelayedLoading(true), 2000);
 		} else {
 			clearTimeout(timeoutId);
 			setDelayedLoading(false);

--- a/vscode-react/src/context/appState.context.tsx
+++ b/vscode-react/src/context/appState.context.tsx
@@ -37,7 +37,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
 	useEffect(() => {
 		let timeoutId: NodeJS.Timeout | undefined;
 		if (state.loading) {
-			timeoutId = setTimeout(() => setDelayedLoading(true), 1000);
+			timeoutId = setTimeout(() => setDelayedLoading(true), 1500);
 		} else {
 			clearTimeout(timeoutId);
 			setDelayedLoading(false);


### PR DESCRIPTION
## Description
Increase loader delay and remove loading state from the sessions view

## Linear Ticket
https://linear.app/autokitteh/issue/UI-336/reduce-sessions-flakyness

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [x] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

