### PR TITLE
fix: live-tail button not displayed after choosing another deployment

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -370,6 +370,7 @@ export class ProjectController {
 		const existingLiveTailState = this.deploymentsWithLiveTail.has(deploymentId);
 		const isFirstTime = !existingLiveTailState;
 		let isLiveStateOn = this.deploymentsWithLiveTail.get(deploymentId);
+
 		if (isFirstTime && this.isDeploymentLiveTailPossible) {
 			isLiveStateOn = true;
 			this.deploymentsWithLiveTail.set(deploymentId, true);
@@ -381,6 +382,11 @@ export class ProjectController {
 		this.view.update({
 			type: MessageType.selectDeployment,
 			payload: this.selectedDeploymentId,
+		});
+
+		this.view.update({
+			type: MessageType.setLiveTailInView,
+			payload: this.isDeploymentLiveTailPossible,
 		});
 	}
 

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -385,7 +385,7 @@ export class ProjectController {
 		});
 
 		this.view.update({
-			type: MessageType.setLiveTailInView,
+			type: MessageType.displayLiveTailButtonInView,
 			payload: this.isDeploymentLiveTailPossible,
 		});
 	}

--- a/src/enums/messageType.enum.ts
+++ b/src/enums/messageType.enum.ts
@@ -34,4 +34,5 @@ export enum MessageType {
 	setConnections = "SET_CONNECTIONS",
 	openConnectionInitURL = "OPEN_CONNECTION_INIT_URL",
 	fetchConnections = "FETCH_CONNECTIONS",
+	setLiveTailInView = "SET_LIVE_TAIL_IN_VIEW",
 }

--- a/src/enums/messageType.enum.ts
+++ b/src/enums/messageType.enum.ts
@@ -34,5 +34,5 @@ export enum MessageType {
 	setConnections = "SET_CONNECTIONS",
 	openConnectionInitURL = "OPEN_CONNECTION_INIT_URL",
 	fetchConnections = "FETCH_CONNECTIONS",
-	setLiveTailInView = "SET_LIVE_TAIL_IN_VIEW",
+	displayLiveTailButtonInView = "DISPLAY_LIVE_TAIL_BUTTON_IN_VIEW",
 }

--- a/vscode-react/src/components/sessions/pages/sessionsSection.component.tsx
+++ b/vscode-react/src/components/sessions/pages/sessionsSection.component.tsx
@@ -19,7 +19,7 @@ export const SessionsSection = ({ height }: { height: string | number }) => {
 	useIncomingMessageHandler({
 		setSessionsSection,
 		setSelectedSession,
-		setLiveTailInView: setIsLiveTailButtonDisplayed,
+		displayLiveTailButtonInView: setIsLiveTailButtonDisplayed,
 	});
 
 	useEffect(() => {

--- a/vscode-react/src/components/sessions/pages/sessionsSection.component.tsx
+++ b/vscode-react/src/components/sessions/pages/sessionsSection.component.tsx
@@ -13,13 +13,18 @@ export const SessionsSection = ({ height }: { height: string | number }) => {
 	const [selectedSession, setSelectedSession] = useState<string | undefined>("");
 	const [stateFilter, setStateFilter] = useState<string>();
 	const [liveTailState, setLiveTailState] = useState<boolean>(true);
-
 	const { sessions, showLiveTail, lastDeployment } = sessionsSection || {};
+	const [isLiveTailButtonDisplayed, setIsLiveTailButtonDisplayed] = useState<boolean>(false);
 
 	useIncomingMessageHandler({
 		setSessionsSection,
 		setSelectedSession,
+		setLiveTailInView: setIsLiveTailButtonDisplayed,
 	});
+
+	useEffect(() => {
+		setLiveTailState(!!showLiveTail || isLiveTailButtonDisplayed);
+	}, [showLiveTail]);
 
 	useForceRerender();
 
@@ -65,7 +70,7 @@ export const SessionsSection = ({ height }: { height: string | number }) => {
 				}
 			>
 				<div className="flex">{`${translate().t("reactApp.sessions.tableTitle")}`}</div>
-				{showLiveTail ? (
+				{isLiveTailButtonDisplayed ? (
 					<div
 						className="ml-3 w-5 h-5 cursor-pointer"
 						onClick={() => toggleLiveTail()}

--- a/vscode-react/src/hooks/useIncomingMessageHandler.hook.ts
+++ b/vscode-react/src/hooks/useIncomingMessageHandler.hook.ts
@@ -47,6 +47,9 @@ export const useIncomingMessageHandler = (handlers: IIncomingMessagesHandler) =>
 				case MessageType.setRetryCountdown:
 					handlers.setRetryCountdown?.(payload as string);
 					break;
+				case MessageType.setLiveTailInView:
+					handlers.setLiveTailInView?.(payload as boolean);
+					break;
 			}
 		};
 

--- a/vscode-react/src/hooks/useIncomingMessageHandler.hook.ts
+++ b/vscode-react/src/hooks/useIncomingMessageHandler.hook.ts
@@ -47,8 +47,8 @@ export const useIncomingMessageHandler = (handlers: IIncomingMessagesHandler) =>
 				case MessageType.setRetryCountdown:
 					handlers.setRetryCountdown?.(payload as string);
 					break;
-				case MessageType.setLiveTailInView:
-					handlers.setLiveTailInView?.(payload as boolean);
+				case MessageType.displayLiveTailButtonInView:
+					handlers.displayLiveTailButtonInView?.(payload as boolean);
 					break;
 			}
 		};

--- a/vscode-react/src/interfaces/incomingMessagesHandler.interface.ts
+++ b/vscode-react/src/interfaces/incomingMessagesHandler.interface.ts
@@ -15,5 +15,6 @@ export interface IIncomingMessagesHandler {
 	setSessionsSection?: (sessions: SessionSectionViewModel | undefined) => void;
 	setPathResponse?: (pathResponse: boolean) => void;
 	setRetryCountdown?: (countdown: string) => void;
+	setLiveTailInView?: (countdown: boolean) => void;
 	setConnections?: (connections: Connection[]) => void;
 }

--- a/vscode-react/src/interfaces/incomingMessagesHandler.interface.ts
+++ b/vscode-react/src/interfaces/incomingMessagesHandler.interface.ts
@@ -15,6 +15,6 @@ export interface IIncomingMessagesHandler {
 	setSessionsSection?: (sessions: SessionSectionViewModel | undefined) => void;
 	setPathResponse?: (pathResponse: boolean) => void;
 	setRetryCountdown?: (countdown: string) => void;
-	setLiveTailInView?: (countdown: boolean) => void;
+	displayLiveTailButtonInView?: (countdown: boolean) => void;
 	setConnections?: (connections: Connection[]) => void;
 }


### PR DESCRIPTION
## Description
Bug:
Live-tail button is not displayed when we:

1. Choose the active deployment
2. Stop the live tail in it
3. Choose another deployment
4. Go back to the active deployment

Fix:

Set the live tail button visibility state every time we choose deployment, by it state (is active or draining).

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [ ] Notify only when user attention is needed, otherwise log to console.
  - [ ] Notifications: short description with context identifiers (e.g. id of the manipulated entity).
  - [ ] Logs: full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [ ] If you're not sure what is the proper behavior, consult with the product team.
- [ ] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [ ] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sorting, fitlering, etc.), not by services, to maintain a clean MVC architecture.
- [ ] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [ ] Avoid using `!important` in CSS where possible.
- [ ] Use memoization for class calculations.
- [ ] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
