### PR TITLE
fix: Avoid fetching build-info on each project load

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -247,18 +247,21 @@ export class ProjectController {
 	}
 
 	async loadSingleshotArgs() {
-		const lastDeployment =
-			this.deployments && this.deployments?.length ? this.deployments[this.deployments.length - 1] : null;
+		if (!this.deployments || !this.deployments.length) {
+			return;
+		}
+		const lastDeployment = this.deployments[this.deployments.length - 1];
 
 		if (this.lastDeploymentId === lastDeployment?.deploymentId) {
 			return;
 		}
-		this.lastDeploymentId = lastDeployment?.deploymentId;
+		this.lastDeploymentId = lastDeployment.deploymentId;
 
 		this.startLoader();
 		const { data: buildDescription, error: buildDescriptionError } = await BuildsService.getBuildDescription(
-			lastDeployment!.buildId
+			lastDeployment.buildId
 		);
+
 		this.stopLoader();
 
 		if (buildDescriptionError) {

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -49,6 +49,7 @@ export class ProjectController {
 	private sessionLogRetryScheduler?: RetryScheduler;
 	private deploymentsRetryStarted: boolean = false;
 	private activeDeploymentSessions?: Session[] = [];
+	private lastDeploymentId?: string;
 
 	constructor(projectView: IProjectView, projectId: string) {
 		this.view = projectView;
@@ -246,15 +247,17 @@ export class ProjectController {
 	}
 
 	async loadSingleshotArgs() {
-		const lastDeployment = this.deployments ? this.deployments[this.deployments?.length - 1] : null;
+		const lastDeployment =
+			this.deployments && this.deployments?.length ? this.deployments[this.deployments.length - 1] : null;
 
-		if (!lastDeployment) {
+		if (this.lastDeploymentId === lastDeployment?.deploymentId) {
 			return;
 		}
+		this.lastDeploymentId = lastDeployment?.deploymentId;
 
 		this.startLoader();
 		const { data: buildDescription, error: buildDescriptionError } = await BuildsService.getBuildDescription(
-			lastDeployment.buildId
+			lastDeployment!.buildId
 		);
 		this.stopLoader();
 


### PR DESCRIPTION
## Description
**Bug:**
We run `buildInfo` of the latest build, to display its functions in the deployment, and every project window focus/unfocus/deployments change which causes redundant calls to the server.

**Recommended solution:**
Fetch it only on project load or when we create a new deployment.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-543/fix-redundant-buildinfo-fetching

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [ ] Notify only when user attention is needed, otherwise log to console.
  - [ ] Notifications: short description with context identifiers (e.g. id of the manipulated entity).
  - [ ] Logs: full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [ ] If you're not sure what is the proper behavior, consult with the product team.
- [ ] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [ ] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sorting, fitlering, etc.), not by services, to maintain a clean MVC architecture.
- [ ] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [ ] Avoid using `!important` in CSS where possible.
- [ ] Use memoization for class calculations.
- [ ] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
