### PR TITLE
feat: move the connections init to local web-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
 					"type": "string",
 					"scope": "machine"
 				},
+				"autokitteh.webInterfaceURL": {
+					"default": "http://localhost:9982",
+					"description": "URL of the web interface",
+					"type": "string",
+					"scope": "machine"
+				},
 				"autokitteh.projectsPaths": {
 					"default": "{}",
 					"description": "Projects directories",

--- a/src/constants/api.constants.ts
+++ b/src/constants/api.constants.ts
@@ -1,5 +1,7 @@
 import { ValidateURL, WorkspaceConfig } from "@utilities";
 
 export const baseURLFromVSCode: string = WorkspaceConfig.getFromWorkspace<string>("baseURL", "");
+export const webUIURLFromVSCode: string = WorkspaceConfig.getFromWorkspace<string>("webInterfaceURL", "");
 
 export const BASE_URL = ValidateURL(baseURLFromVSCode) ? baseURLFromVSCode : "";
+export const WEB_UI_URL = ValidateURL(webUIURLFromVSCode) ? webUIURLFromVSCode : "";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,7 +8,7 @@ export {
 	INITIAL_PROJECTS_RETRY_SCHEDULE_INTERVAL,
 	INITIAL_SERVER_HEALTH_SCHEDULE_INTERVAL,
 } from "@constants/extensionConfiguration.constants";
-export { BASE_URL } from "@constants/api.constants";
+export { BASE_URL, WEB_UI_URL } from "@constants/api.constants";
 export { vsCommands } from "@constants/vsCommands.constants";
 export { namespaces } from "@constants/namespaces.logger.constants";
 export { channels } from "@constants/output.constants";

--- a/src/controllers/connections.controller.ts
+++ b/src/controllers/connections.controller.ts
@@ -1,6 +1,6 @@
 import { commands, env, Uri } from "vscode";
 
-import { BASE_URL, namespaces, vsCommands } from "@constants";
+import { namespaces, vsCommands, WEB_UI_URL } from "@constants";
 import { MessageType } from "@enums";
 import eventEmitter from "@eventEmitter";
 import { translate } from "@i18n";
@@ -47,8 +47,10 @@ export class ConnectionsController {
 		});
 	}
 
-	async openConnectionInitURL(connectionInit: { connectionName: string; initURL: string; connectionId: string }) {
-		const connectionInitURL = Uri.parse(`${BASE_URL}${connectionInit.initURL}`);
+	async openConnectionInitURL(connectionInit: { connectionName: string; connectionId: string }) {
+		const connectionInitURL = Uri.parse(
+			`${WEB_UI_URL}/projects/${this.projectId}/connections/${connectionInit.connectionId}/edit`
+		);
 
 		const initLinkOpenInBrowser = await env.openExternal(connectionInitURL);
 

--- a/src/interfaces/projectView.interface.ts
+++ b/src/interfaces/projectView.interface.ts
@@ -31,7 +31,6 @@ export interface ProjectViewDelegate {
 export interface ConnectionsViewDelegate {
 	openConnectionInitURL?: Callback<{
 		connectionName: string;
-		initURL: string;
 		connectionId: string;
 	}>;
 	openConnectionsModal?: Callback;

--- a/src/views/project.view.ts
+++ b/src/views/project.view.ts
@@ -91,7 +91,7 @@ export class ProjectView implements IProjectView {
 						break;
 					case MessageType.openConnectionInitURL:
 						this.delegate?.connections.openConnectionInitURL?.(
-							message.payload as { connectionName: string; initURL: string; connectionId: string }
+							message.payload as { connectionName: string; connectionId: string }
 						);
 						break;
 					case MessageType.fetchConnections:

--- a/vscode-react/src/components/connections/organisms/connectionsModal.component.tsx
+++ b/vscode-react/src/components/connections/organisms/connectionsModal.component.tsx
@@ -21,8 +21,8 @@ export const ConnectionsModal = ({ onClose }: { onClose: () => void }) => {
 		setConnections,
 	});
 
-	const handleConnectionInitClick = (connectionName: string, connectionInitURL: string, connectionId: string) => {
-		sendMessage(MessageType.openConnectionInitURL, { connectionName, initURL: connectionInitURL, connectionId });
+	const handleConnectionInitClick = (connectionName: string, connectionId: string) => {
+		sendMessage(MessageType.openConnectionInitURL, { connectionName, connectionId });
 	};
 
 	const handleRefreshClick = () => {
@@ -66,7 +66,7 @@ export const ConnectionsModal = ({ onClose }: { onClose: () => void }) => {
 									<HeaderCell>{translate().t("reactApp.connections.tableColumns.information")}</HeaderCell>
 									<HeaderCell>{translate().t("reactApp.connections.tableColumns.actions")}</HeaderCell>
 								</TableHeader>
-								{connections.map(({ connectionId, name, integrationName, status, statusInfoMessage, initURL }) => (
+								{connections.map(({ connectionId, name, integrationName, status, statusInfoMessage }) => (
 									<Row key={connectionId}>
 										<Cell classes={["text-vscode-foreground"]}>{name}</Cell>
 										<Cell classes={["text-vscode-foreground"]}>{integrationName}</Cell>
@@ -75,9 +75,9 @@ export const ConnectionsModal = ({ onClose }: { onClose: () => void }) => {
 										</Cell>
 										<Cell classes={["text-vscode-foreground"]}>{statusInfoMessage}</Cell>
 										<Cell classes={["flex justify-center align-center"]}>
-											{initURL && (
+											{connectionId && (
 												<div
-													onClick={() => handleConnectionInitClick(name, initURL, connectionId)}
+													onClick={() => handleConnectionInitClick(name, connectionId)}
 													className="w-3 codicon codicon-gear text-white cursor-pointer"
 													title={translate().t("reactApp.connections.init")}
 												/>


### PR DESCRIPTION
## Description
In the VSCode extension in the connection modal change the init URL from: http://localhost:9980/connections/con_01j9tng29ffp89djt2zf3qqb3r/init/vscode -> http://localhost:9982/projects/prj_01j9tng290fvpapn0et43n5eq4/connections/con_01j9tng29ffp89djt2zf3qqb3r/edit

From: http://HOST_URL/connections/con_01j9tng29ffp89djt2zf3qqb3r/init/vscode

To: http://WEB_UI_URL/projects/{projectId}/connections/{connectionId}/edit

## Linear Ticket
https://linear.app/autokitteh/issue/UI-707/vscode-point-connections-to-the-webui

## What type of PR is this? (check all applicable)

- [x] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
