### PR TITLE
fix(UI-1412): deployments fetch optimization on project tab focus

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -37,6 +37,7 @@ export class ProjectController {
 	private sessionsNextPageToken?: string;
 	private deploymentsWithLiveTail: Map<string, boolean> = new Map();
 	private lastDeploymentId?: string;
+	private isNewPageInstance: boolean = true;
 
 	constructor(projectView: IProjectView, projectId: string) {
 		this.view = projectView;
@@ -1039,13 +1040,12 @@ export class ProjectController {
 	}
 
 	async loadInitialDataOnceViewReady() {
-		this.loadAndDisplayDeployments();
-
-		const isResourcesPathExist = await this.getResourcesPathFromContext();
-		if (isResourcesPathExist) {
-			this.notifyViewResourcesPathChanged();
+		if (!this.isNewPageInstance) {
 			return;
 		}
+		this.isNewPageInstance = false;
+		this.loadAndDisplayDeployments();
+		this.notifyViewResourcesPathChanged();
 	}
 
 	async refreshUI() {


### PR DESCRIPTION
## Description
On the following flow:
1. Open a project
2. Move to another tab (another project or a code file)
3. Back to the project tab

We were fetching the deployments from the backend twice: the first time in the `enable` function which is triggered `onFocus`, and the second time in `loadInitialDataOnceViewReady` when the `deploymentsSection` component was successfully mounted. On the second time, we weren't sending it to the UI, because of this condition `if (isEqual(this.deployments, deployments))` but the extension was sending the requests for the deployments list twice.

The change protects the `loadInitialDataOnceViewReady` function from running together with `enable` and `onFocus` and runs only once - when the project opens for the first time.

## Linear Ticket

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A New Feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white spaces, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

## Code Standards
- [ ] Notify only when user attention is needed, otherwise log to console.
  - [ ] Notification ns: a short description with context identifiers (e.g. id of the manipulated entity).
  - [ ] Logsa: a full description with full context identifiers (e.g. deploymentId and the relevant projectId).
- [ ] If you're not sure what is the proper behavior, consult with the product team.
- [ ] Reduce the use of `else` by employing early returns to make code more readable and less nested.
- [ ] MVC Separation: Ensure separation of concerns; views should only be manipulated by controllers (also the computing - sortifilteringring, etc.), not by services, to maintain a clean MVC architecture.
- [ ] Before implementing custom logic, check if existing functions or utilities (like lodash) offer a simpler solution.
- [ ] Avoid using `!important` in CSS where possible.
- [ ] Use memoization for class calculations.
- [ ] Place constant strings in your code using I18n.


<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.

     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
